### PR TITLE
syntax fixes from Triada

### DIFF
--- a/AntistasiOfficial.Altis/AI/airCA.sqf
+++ b/AntistasiOfficial.Altis/AI/airCA.sqf
@@ -3,11 +3,11 @@ This script should send a jet to chase the FIA aircraft which is annoying AAF.
 0 = blufor aircraft
 */
 
-_FIAaricraft = _this select 0
+_FIAaricraft = _this select 0;
 _targetpos = position (_FIAaricraft);
 
 _airport = [_targetpos] call AS_fnc_findAirportForCA;
-_airportpos = getmakerpos [_airport];
+_airportpos = getmarkerpos [_airport];
 _depart = [_airportpos select 0, _airportpos select 1,300];
 _jet = [_depart, 0,dogfight, side_green] call bis_fnc_spawnvehicle;
 _pilot = driver (_jet select 0);

--- a/AntistasiOfficial.Altis/CREATE/createNATObases.sqf
+++ b/AntistasiOfficial.Altis/CREATE/createNATObases.sqf
@@ -106,35 +106,35 @@ _allGroups pushBack _group;
 	};
 	*/
 
-	//Initialise NATO units
-	_groupType = [bluTeam, side_blue] call AS_fnc_pickGroup;
-	_group = [_markerPos, side_blue, _groupType] call BIS_Fnc_spawnGroup;
-	sleep 1;
-	[leader _group, _marker, "SAFE", "ORIGINAL","SPAWNED", "NOVEH2", "NOFOLLOW"] execVM "scripts\UPSMON.sqf";
-	_allGroups pushBack _group;
+//Initialise NATO units
+_groupType = [bluTeam, side_blue] call AS_fnc_pickGroup;
+_group = [_markerPos, side_blue, _groupType] call BIS_Fnc_spawnGroup;
+sleep 1;
+[leader _group, _marker, "SAFE", "ORIGINAL","SPAWNED", "NOVEH2", "NOFOLLOW"] execVM "scripts\UPSMON.sqf";
+_allGroups pushBack _group;
 
-	_counter = 0;
-	while {(spawner getVariable _marker) AND (_counter < _maxVehicles)} do {
-		if (diag_fps > minimoFPS) then {
-			while {true} do {
-				_spawnPos = [_markerPos, random _size,random 360] call BIS_fnc_relPos;
-				if (!surfaceIsWater _spawnPos) exitWith {};
-			};
-
-			_groupType = [bluTeam, side_blue] call AS_fnc_pickGroup;
-			_group = [_spawnPos,side_blue, _groupType] call BIS_Fnc_spawnGroup;
-			sleep 1;
-			if (_counter == 0) then {
-				[leader _group, _marker, "SAFE","SPAWNED","FORTIFY","NOVEH","NOFOLLOW"] execVM "scripts\UPSMON.sqf";
-			} else {
-				[leader _group, _marker, "SAFE","SPAWNED", "RANDOM","NOVEH", "NOFOLLOW"] execVM "scripts\UPSMON.sqf";
-			};
-			_allGroups pushBack _group;
+_counter = 0;
+while {(spawner getVariable _marker) AND (_counter < _maxVehicles)} do {
+	if (diag_fps > minimoFPS) then {
+		while {true} do {
+			_spawnPos = [_markerPos, random _size,random 360] call BIS_fnc_relPos;
+			if (!surfaceIsWater _spawnPos) exitWith {};
 		};
 
-		_counter = _counter + 1;
+		_groupType = [bluTeam, side_blue] call AS_fnc_pickGroup;
+		_group = [_spawnPos,side_blue, _groupType] call BIS_Fnc_spawnGroup;
+		sleep 1;
+		if (_counter == 0) then {
+			[leader _group, _marker, "SAFE","SPAWNED","FORTIFY","NOVEH","NOFOLLOW"] execVM "scripts\UPSMON.sqf";
+		} else {
+			[leader _group, _marker, "SAFE","SPAWNED", "RANDOM","NOVEH", "NOFOLLOW"] execVM "scripts\UPSMON.sqf";
+		};
+		_allGroups pushBack _group;
 	};
+
+	_counter = _counter + 1;
 };
+
 
 //Create groups for FIA garrison
 	_gunnerGroup = createGroup side_blue;

--- a/AntistasiOfficial.Altis/JeroenArsenal/Shit Jeroen.sqf
+++ b/AntistasiOfficial.Altis/JeroenArsenal/Shit Jeroen.sqf
@@ -161,7 +161,7 @@ vehicle player addEventHandler ["Fired", {
 		};
 	};
 
-}]
+}];
 
 
 player allowDamage false;
@@ -174,7 +174,7 @@ vehicle player addEventHandler ["Fired", {
 		_p setVelocity (velocity _this);
 	};
 
-}]
+}];
 
 
 

--- a/AntistasiOfficial.Altis/Scripts/BE_modul.sqf
+++ b/AntistasiOfficial.Altis/Scripts/BE_modul.sqf
@@ -464,7 +464,7 @@ fnc_BE_broadcast = {
 			_bool = _data select 0;
 			_str = _data select 1;
 
-			_boolStr = ["not satisfied", "satisfied"] select _bool, true;
+			_boolStr = ["not satisfied", "satisfied"] select _bool;
 			_pI pushBack (format ["Requirement: %1 \nStatus: %2", _str, _boolStr]);
 		} forEach _reqs;
 	};

--- a/AntistasiOfficial.Altis/Scripts/UPSMON/COMMON/Core/fnc/UPSMON_Getunitsincargo.sqf
+++ b/AntistasiOfficial.Altis/Scripts/UPSMON/COMMON/Core/fnc/UPSMON_Getunitsincargo.sqf
@@ -9,8 +9,8 @@ Parameter(s):
 Returns:
 
 ****************************************************************/
-private["_vehicle","_unitsincargo","_crew"];	
-				
+private["_vehicle","_unitsincargo","_crew"];
+
 _vehicle = _this select 0;
 
 _unitsincargo = [];
@@ -20,7 +20,7 @@ _crew = crew _vehicle;
 {
 	If (alive _x) then
 	{
-		If () then
+		If (true) then
 		{
 			_unitsincargo pushback _x;
 		};

--- a/AntistasiOfficial.Altis/Templates/BLUE_NATO.sqf
+++ b/AntistasiOfficial.Altis/Templates/BLUE_NATO.sqf
@@ -12,7 +12,7 @@
 
 	//Categories
 	planesNATOTrans = bluHeliTrans;									// \Create\NATOCA.sqf selectrandom
-	planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW + bluHeliTS + bluHeliDis, bluHeliRope;	//All Air Assets
+	planesNATO = bluHeliTrans + bluHeliArmed + bluHeliGunship + bluCASFW + bluHeliTS + bluHeliDis + bluHeliRope;	//All Air Assets
 
 //Groundvehicles		//Class id									//.sqf presence
 	bluMBT = 			["B_MBT_01_cannon_F","B_MBT_01_TUSK_F"];	// \CREATE\NATOArmor.sqf selectrandom

--- a/AntistasiOfficial.Altis/Worlds/MaldenData.sqf
+++ b/AntistasiOfficial.Altis/Worlds/MaldenData.sqf
@@ -14,7 +14,7 @@ controles = ["control_1","control_2","control_3"]; // roadblocks
 colinas = []; // mountaintops
 colinasAA = []; // mountaintops for special purposes (compositions, etc)
 artyEmplacements = ["artillery_1","artillery_2","artillery_3"]; // artillery encampments
-seaMarkers = ["seaPatrol_1","seaPatrol_2","seaPatrol_3","seaPatrol_4","seaPatrol_5","seaPatrol_6","seaPatrol_7","seaPatrol_8","seaPatrol_9","seaPatrol_10","seaPatrol_11","seaPatrol_12","seaPatrol_13","seaPatrol_14",]; // naval patrol zones
+seaMarkers = ["seaPatrol_1","seaPatrol_2","seaPatrol_3","seaPatrol_4","seaPatrol_5","seaPatrol_6","seaPatrol_7","seaPatrol_8","seaPatrol_9","seaPatrol_10","seaPatrol_11","seaPatrol_12","seaPatrol_13","seaPatrol_14"]; // naval patrol zones
 
 posAntenas = [[7001.08,10034.1,0],[7057.09,9932.42,0],[9635.78,3309.5,0],[11320,4122.09,0]];
 

--- a/AntistasiOfficial.Altis/orgPlayers/assignStavros.sqf
+++ b/AntistasiOfficial.Altis/orgPlayers/assignStavros.sqf
@@ -55,5 +55,5 @@ _selectable = objNull;
 if (!isNull _selectable) then {
  	[_selectable] call stavrosInit;
 	sleep 5;
-	[[name Slowhand, name _selectable, _disconnected],{_text ="", if (_this select 2) then {_text = format [localize "STR_HINTS_COMMANDER_DIS", _this select 1]} else {_text = format [localize "STR_HINTS_COMMANDER_REP", _this select 0, _this select 1]}; hint _text;}] remoteExec ["call",0];
+	[[name Slowhand, name _selectable, _disconnected],{_text =""; if (_this select 2) then {_text = format [localize "STR_HINTS_COMMANDER_DIS", _this select 1]} else {_text = format [localize "STR_HINTS_COMMANDER_REP", _this select 0, _this select 1]}; hint _text;}] remoteExec ["call",0];
 };

--- a/AntistasiOfficial.Altis/shitstef.sqf
+++ b/AntistasiOfficial.Altis/shitstef.sqf
@@ -21,7 +21,7 @@ waitUntil
 		(
     	2*count (allUnits select {(side _x == side_blue) AND (_x distance _markerPos <= 100) and (lifeState _x != "INCAPACITATED") and !(fleeing _x)})
    		<
-    	count (allUnits select {((side _x == side_green) OR (side _x == side_red)) AND (_x distance _markerPos <= 100) and (lifeState _x != "INCAPACITATED")}
+    	count (allUnits select {((side _x == side_green) OR (side _x == side_red)) AND (_x distance _markerPos <= 100) and (lifeState _x != "INCAPACITATED")})
     )
 	)
 };
@@ -30,7 +30,7 @@ if ((_marker in mrkAAF) or (
     	2*count (allUnits select {(side _x == side_blue) AND (_x distance _markerPos <= 100) and (lifeState _x != "INCAPACITATED") and !(fleeing _x)})
    		<
     	count (allUnits select {((side _x == side_green) OR (side _x == side_red)) AND (_x distance _markerPos <= 100) and (lifeState _x != "INCAPACITATED")}
-    )) then {hint "WIN"} else {hint "LOSS"};
+    ))) then {hint "WIN"} else {hint "LOSS"};
 
 
 
@@ -180,7 +180,7 @@ if (_vehicleType in heli_armed + opAir + opCASFW) exitWith {
 			if (random 8 < 1) then { //maybe add spawn here
 				if(player in crew _vehicle) then {
 					_targetpos = position (_vehicle);
-					_airportpos = getmakerpos ["spawnCSAT"];
+					_airportpos = getmarkerpos ["spawnCSAT"];
 					_depart = [_airportpos select 0, _airportpos select 1,300];
 					_jet = [_depart, 0,dogfight, side_green] call bis_fnc_spawnvehicle;
 					_pilot = driver (_jet select 0);
@@ -189,9 +189,9 @@ if (_vehicleType in heli_armed + opAir + opCASFW) exitWith {
 
 				};
 			};
-		};
-	};
-
+		}
+	];
+};
 _vehicle = vehicle player;
 _eh = _vehicle addEventHandler ["Fired", {
     	if(player in crew _vehicle) then {

--- a/AntistasiOfficial.Altis/undercover.sqf
+++ b/AntistasiOfficial.Altis/undercover.sqf
@@ -100,7 +100,7 @@ call {
     	_revealdist = 100;
     	if (_base in puestos) then {_revealdist = 60} else {_revealdist = 300};
     	if (player distance getMarkerPos _base < _revealdist) exitWith {_reason = localize "STR_HINTS_UND_FAC_GRND"};
-    }
+    };
 
 	// You are wearing compromising gear
 	call {


### PR DESCRIPTION
airCA.sqf - lost ";", getmarkerpos
createNATObases.sqf - delete extra "};"
Shit Jeroen.sqf - lost 2 ";"
BE_modul.sqf - fix incorrect code
UPSMON_Getunitsincargo.sqf - fix incorrect logic
BLUE_NATO.sqf - fix wrong "," to "+"
MaldenData.sqf - delete extra ","
assignStavros.sqf - fix wrong "," to ";"
shitstef.sqf - fix losts ")" and more
undercover.sqf - fix lost ";"



